### PR TITLE
Agrega hack para que mdl aplique estilos.

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -1,6 +1,5 @@
 <head><link rel="stylesheet" href="css/material.min.css">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<script src="js/material.min.js"></script>
 <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 <link rel="stylesheet" href="css/style.css">
 <title>OvnionPanel</title>
@@ -9,4 +8,5 @@
 
 <body>
 	<script defer src='bundle.js' type='text/javascript'></script>
+<script src="js/material.min.js"></script>
 </body>

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,23 @@ worker.onmessage = function (ev) {
     return document.body.appendChild(el)
   }
   yo.update(el, newel)
-
+  if (
+      'classList' in document.documentElement &&
+      'querySelector' in document &&
+      'addEventListener' in window &&
+      'forEach' in Array.prototype) {
+    document.documentElement.classList.add('mdl-js');
+    componentHandler.upgradeAllRegistered();
+  } else {
+    /**
+     * Dummy function to avoid JS errors.
+     */
+    componentHandler.upgradeElement = function() {};
+    /**
+     * Dummy function to avoid JS errors.
+     */
+    componentHandler.register = function() {};
+  }
 /* Si la url de la barra de navegacion no coincide con la recibida, la actualizamos. */
   if (location.pathname !== url) {
     history.pushState(null, null, url)


### PR DESCRIPTION
Material design lite, para aplicar estilos y animaciones escucha el
evento load y ejecuta el codigo agregado en el hack, proveniente del
archivo mdlComponentHandler.js.

Este es un parche temporal hasta que implementemos mdl como modulos
commonjs.
